### PR TITLE
BMSCP-2: Add Jenkinsfile, Dockerfile, k8s manifests placeholders

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --only=production
+COPY . .
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,38 @@
+pipeline {
+  agent any
+  environment {
+    DOCKER_REG = "preeti730"   // change if different
+    IMAGE_NAME = "book-my-show"
+    IMAGE_TAG  = "${env.GIT_COMMIT.take(7)}"
+  }
+  stages {
+    stage('Checkout') { steps { checkout scm } }
+    stage('Install & Test') {
+      steps {
+        sh 'npm ci || true'
+        sh 'npm test || true'
+      }
+    }
+    stage('Build Docker') {
+      steps {
+        sh "docker build -t ${DOCKER_REG}/${IMAGE_NAME}:${IMAGE_TAG} ."
+      }
+    }
+    stage('Push Image') {
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'dockerhub-creds', usernameVariable: 'DOCKER_USER', passwordVariable: 'DOCKER_PASS')]) {
+          sh 'echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin'
+          sh "docker push ${DOCKER_REG}/${IMAGE_NAME}:${IMAGE_TAG}"
+        }
+      }
+    }
+    stage('Deploy K8s (optional)') {
+      steps {
+        withCredentials([file(credentialsId: 'kubeconfig-file', variable: 'KUBECONFIG_FILE')]) {
+          sh 'export KUBECONFIG=$KUBECONFIG_FILE && kubectl apply -f k8s/'
+        }
+      }
+    }
+  }
+  post { success { echo "Pipeline success" } failure { echo "Pipeline failed" } }
+}

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bookmyshow-app
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: bookmyshow
+  template:
+    metadata:
+      labels:
+        app: bookmyshow
+    spec:
+      containers:
+      - name: bookmyshow
+        image: preetishinge/book-my-show:dev   # placeholder; Jenkins will push with tag
+        ports:
+        - containerPort: 3000
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 10

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bookmyshow-svc
+spec:
+  type: LoadBalancer
+  selector:
+    app: bookmyshow
+  ports:
+  - port: 80
+    targetPort: 3000


### PR DESCRIPTION
## Summary
Added placeholders for Jenkinsfile, Dockerfile, and Kubernetes manifests (deployment.yaml & service.yaml) for Book-My-Show CI/CD pipeline.

## Details
- Jenkinsfile: CI/CD skeleton
- Dockerfile: basic structure
- k8s/deployment.yaml & k8s/service.yaml: placeholder manifests

## Jira
Linked to Jira issue: D02 — GitHub PR link

## Acceptance Criteria
- [ ] Branch created from latest main
- [ ] PR opened to akshu20791/Book-My-Show main
- [ ] PR link added to Jira issue D02 (deliverable)
